### PR TITLE
Fix #32 dont escape twice in CSRFProtection

### DIFF
--- a/app/views/admin/pages/edit.html.erb
+++ b/app/views/admin/pages/edit.html.erb
@@ -67,7 +67,7 @@
 <script type="text/javascript">
   // Make sure that every Ajax request sends the CSRF token
   function CSRFProtection(xhr) {
-    var token = "<%= Rack::Utils.escape_html(form_authenticity_token) %>";
+    var token = "<%= form_authenticity_token.html_safe %>";
     if (token) xhr.setRequestHeader('X-CSRF-Token', token);
   }
 


### PR DESCRIPTION
Some characters in the token were escaped badly before this
